### PR TITLE
chainer/bilstm-tagger-withchar.py gpu bug fix

### DIFF
--- a/chainer/bilstm-tagger-withchar.py
+++ b/chainer/bilstm-tagger-withchar.py
@@ -155,7 +155,7 @@ class Tagger(Chain):
 
 tagger = Tagger()
 
-if chainer_gpu >= 0:
+if args.chainer_gpu >= 0:
   tagger.to_gpu()
 
 trainer = O.Adam()


### PR DESCRIPTION
chainer/bilstm-tagger-withchar.py does not work currently. This one line change of code fixes the issue.