### PR TITLE
Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ install:
 #  - cd $TRAVIS_BUILD_DIR
 
 script:
-  - env DYFLAGS="--dynet-mem 2048" TIMEOUT=120 LONGTIMEOUT=300 ./run-tests.sh
+  - env DYFLAGS="--dynet-mem 2048" TIMEOUT=30 LONGTIMEOUT=60 ./run-tests.sh
   - grep '\(per_sec\|startup\)' log/*/*.log
 
 after_failure:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,40 @@
+dist: trusty
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+      - boost-latest
+    packages:
+      - g++-4.8
+      - libboost-regex1.55-dev
+jobs:
+  include:
+    - language: python
+      python: 2.7
+      env: PY=cp27-cp27mu
+    - language: python
+      python: 3.6
+      env: PY=cp36-cp36m
+
+install:
+  - pip install -q chainer http://download.pytorch.org/whl/cu75/torch-0.2.0.post3-$PY-manylinux1_x86_64.whl torchvision tensorflow theano cython numpy
+  - hg clone https://bitbucket.org/eigen/eigen -r 699b659
+  - git clone https://github.com/clab/dynet
+  - export DYNET_PATH=$PWD/dynet EIGEN_PATH=$PWD/eigen
+  - mkdir dynet/build
+  - cd dynet/build
+  - cmake .. -DEIGEN3_INCLUDE_DIR=$TRAVIS_BUILD_DIR/eigen -DPYTHON=$(which python) -DCMAKE_INSTALL_PREFIX=$(dirname $(which python))/..
+  - make -j$(nproc)
+  - cd python
+  - python ../../setup.py build --build-dir=.. --skip-build install
+  - cd $TRAVIS_BUILD_DIR/dynet-cpp
+  - make DYNET_PATH=$DYNET_PATH EIGEN_PATH=$EIGEN_PATH
+  - cd $TRAVIS_BUILD_DIR
+
+script:
+  - env DYFLAGS="--dynet-mem 2048" TIMEOUT=120 LONGTIMEOUT=300 ./run-tests.sh
+  - grep '\(per_sec\|startup\)' log/*/*.log
+
+after_failure:
+  - cat $TRAVIS_BUILD_DIR/log/*/*.log
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ python:
 env:
   - TEST=dynet
   - TEST=chainer
-  - TEST=tensorflow
   - TEST=theano
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
   - TEST=theano
 matrix:
   include:
-    - language: cpp
+    - env: TEST=dynet-cpp
       addons:
         apt:
           sources:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,17 +7,20 @@ dist: trusty
 #    packages:
 #      - g++-4.8
 #      - libboost-regex1.55-dev
-jobs:
-  include:
-    - language: python
-      python: 2.7
-      env: PY=cp27-cp27mu
-    - language: python
-      python: 3.6
-      env: PY=cp36-cp36m
+language: python
+python:
+  - 2.7
+  - 3.6
+env:
+  - TEST=dynet
+  - TEST=chainer
+  - TEST="http://download.pytorch.org/whl/cu75/torch-0.2.0.post3-`python python-tag-abi-tag.py`-manylinux1_x86_64.whl torchvision"
+  - TEST=tensorflow
+  - TEST=theano
 
 install:
-  - pip install -q dynet chainer http://download.pytorch.org/whl/cu75/torch-0.2.0.post3-$PY-manylinux1_x86_64.whl torchvision tensorflow theano cython numpy
+  - pip install -q cython numpy
+  - pip install -q $TEST
 #  - hg clone https://bitbucket.org/eigen/eigen -r 699b659
 #  - git clone https://github.com/clab/dynet
 #  - export DYNET_PATH=$PWD/dynet EIGEN_PATH=$PWD/eigen

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ python:
 env:
   - TEST=dynet
   - TEST=chainer
-  - TEST="http://download.pytorch.org/whl/cu75/torch-0.2.0.post3-`python python-tag-abi-tag.py`-manylinux1_x86_64.whl torchvision"
   - TEST=tensorflow
   - TEST=theano
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ dist: trusty
 language: python
 python:
   - 2.7
-  - 3.6
 env:
   - TEST=dynet
   - TEST=chainer

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,10 @@ matrix:
         - make DYNET_PATH=$DYNET_PATH EIGEN_PATH=$EIGEN_PATH
         - cd $TRAVIS_BUILD_DIR
 
-install:
+before_install:
   - pip install -q cython numpy
+
+install:
   - pip install $TEST
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,4 @@
 dist: trusty
-#addons:
-#  apt:
-#    sources:
-#      - ubuntu-toolchain-r-test
-#      - boost-latest
-#    packages:
-#      - g++-4.8
-#      - libboost-regex1.55-dev
 language: python
 python:
   - 2.7
@@ -17,22 +9,34 @@ env:
   - TEST="http://download.pytorch.org/whl/cu75/torch-0.2.0.post3-`python python-tag-abi-tag.py`-manylinux1_x86_64.whl torchvision"
   - TEST=tensorflow
   - TEST=theano
+matrix:
+  include:
+    - language: cpp
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - boost-latest
+          packages:
+            - g++-4.8
+            - libboost-regex1.55-dev
+      install:
+        - hg clone https://bitbucket.org/eigen/eigen -r 699b659
+        - git clone https://github.com/clab/dynet
+        - export DYNET_PATH=$PWD/dynet EIGEN_PATH=$PWD/eigen
+        - mkdir dynet/build
+        - cd dynet/build
+        - cmake .. -DEIGEN3_INCLUDE_DIR=$TRAVIS_BUILD_DIR/eigen -DPYTHON=$(which python) -DCMAKE_INSTALL_PREFIX=$(dirname $(which python))/..
+        - make -j$(nproc)
+#        - cd python
+#        - python ../../setup.py build --build-dir=.. --skip-build install
+        - cd $TRAVIS_BUILD_DIR/dynet-cpp
+        - make DYNET_PATH=$DYNET_PATH EIGEN_PATH=$EIGEN_PATH
+        - cd $TRAVIS_BUILD_DIR
 
 install:
   - pip install -q cython numpy
-  - pip install -q $TEST
-#  - hg clone https://bitbucket.org/eigen/eigen -r 699b659
-#  - git clone https://github.com/clab/dynet
-#  - export DYNET_PATH=$PWD/dynet EIGEN_PATH=$PWD/eigen
-#  - mkdir dynet/build
-#  - cd dynet/build
-#  - cmake .. -DEIGEN3_INCLUDE_DIR=$TRAVIS_BUILD_DIR/eigen -DPYTHON=$(which python) -DCMAKE_INSTALL_PREFIX=$(dirname $(which python))/..
-#  - make -j$(nproc)
-#  - cd python
-#  - python ../../setup.py build --build-dir=.. --skip-build install
-#  - cd $TRAVIS_BUILD_DIR/dynet-cpp
-#  - make DYNET_PATH=$DYNET_PATH EIGEN_PATH=$EIGEN_PATH
-#  - cd $TRAVIS_BUILD_DIR
+  - pip install $TEST
 
 script:
   - env DYFLAGS="--dynet-mem 2048" TIMEOUT=30 LONGTIMEOUT=60 ./run-tests.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 dist: trusty
-addons:
-  apt:
-    sources:
-      - ubuntu-toolchain-r-test
-      - boost-latest
-    packages:
-      - g++-4.8
-      - libboost-regex1.55-dev
+#addons:
+#  apt:
+#    sources:
+#      - ubuntu-toolchain-r-test
+#      - boost-latest
+#    packages:
+#      - g++-4.8
+#      - libboost-regex1.55-dev
 jobs:
   include:
     - language: python
@@ -17,19 +17,19 @@ jobs:
       env: PY=cp36-cp36m
 
 install:
-  - pip install -q chainer http://download.pytorch.org/whl/cu75/torch-0.2.0.post3-$PY-manylinux1_x86_64.whl torchvision tensorflow theano cython numpy
-  - hg clone https://bitbucket.org/eigen/eigen -r 699b659
-  - git clone https://github.com/clab/dynet
-  - export DYNET_PATH=$PWD/dynet EIGEN_PATH=$PWD/eigen
-  - mkdir dynet/build
-  - cd dynet/build
-  - cmake .. -DEIGEN3_INCLUDE_DIR=$TRAVIS_BUILD_DIR/eigen -DPYTHON=$(which python) -DCMAKE_INSTALL_PREFIX=$(dirname $(which python))/..
-  - make -j$(nproc)
-  - cd python
-  - python ../../setup.py build --build-dir=.. --skip-build install
-  - cd $TRAVIS_BUILD_DIR/dynet-cpp
-  - make DYNET_PATH=$DYNET_PATH EIGEN_PATH=$EIGEN_PATH
-  - cd $TRAVIS_BUILD_DIR
+  - pip install -q dynet chainer http://download.pytorch.org/whl/cu75/torch-0.2.0.post3-$PY-manylinux1_x86_64.whl torchvision tensorflow theano cython numpy
+#  - hg clone https://bitbucket.org/eigen/eigen -r 699b659
+#  - git clone https://github.com/clab/dynet
+#  - export DYNET_PATH=$PWD/dynet EIGEN_PATH=$PWD/eigen
+#  - mkdir dynet/build
+#  - cd dynet/build
+#  - cmake .. -DEIGEN3_INCLUDE_DIR=$TRAVIS_BUILD_DIR/eigen -DPYTHON=$(which python) -DCMAKE_INSTALL_PREFIX=$(dirname $(which python))/..
+#  - make -j$(nproc)
+#  - cd python
+#  - python ../../setup.py build --build-dir=.. --skip-build install
+#  - cd $TRAVIS_BUILD_DIR/dynet-cpp
+#  - make DYNET_PATH=$DYNET_PATH EIGEN_PATH=$EIGEN_PATH
+#  - cd $TRAVIS_BUILD_DIR
 
 script:
   - env DYFLAGS="--dynet-mem 2048" TIMEOUT=120 LONGTIMEOUT=300 ./run-tests.sh

--- a/python-tag-abi-tag.py
+++ b/python-tag-abi-tag.py
@@ -1,0 +1,7 @@
+# Utility script to print the python tag + the abi tag for a Python
+# See PEP 425 for exactly what these are, but an example would be:
+#   cp27-cp27mu
+
+from wheel.pep425tags import get_abbr_impl, get_impl_ver, get_abi_tag
+
+print("{0}{1}-{2}".format(get_abbr_impl(), get_impl_ver(), get_abi_tag()))

--- a/python-tag-abi-tag.py
+++ b/python-tag-abi-tag.py
@@ -1,7 +1,0 @@
-# Utility script to print the python tag + the abi tag for a Python
-# See PEP 425 for exactly what these are, but an example would be:
-#   cp27-cp27mu
-
-from wheel.pep425tags import get_abbr_impl, get_impl_ver, get_abi_tag
-
-print("{0}{1}-{2}".format(get_abbr_impl(), get_impl_ver(), get_abi_tag()))

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
 
-export ANACONDA_PATH=$HOME/usr/local/anaconda3/envs/benchmark2
+export PYTHON_PATH={ANACONDA_PATH:-$HOME/usr/local/anaconda3/envs/benchmark2}
 export CUDA_PATH=/usr/local/cuda
-export DYNET_PATH=$HOME/work/dynet
-export LD_LIBRARY_PATH=$DYNET_PATH/build/dynet:$ANACONDA_PATH/lib:$CUDA_PATH/lib64
-export LIBRARY_PATH=$DYNET_PATH/build/dynet:$ANACONDA_PATH/lib:$CUDA_PATH/lib64
+export DYNET_PATH=${DYNET_PATH:-$HOME/work/dynet}
+export LD_LIBRARY_PATH=$DYNET_PATH/build/dynet:$PYTHON_PATH/lib:$CUDA_PATH/lib64
+export LIBRARY_PATH=$DYNET_PATH/build/dynet:$PYTHON_PATH/lib:$CUDA_PATH/lib64
 export PYTHONPATH=$DYNET_PATH/build/python
 PYTHON=python
 
-DYFLAGS="--dynet-mem 4096"
+DYFLAGS=${DYFLAGS:-"--dynet-mem 4096"}
 GPUSUF=
 if [[ $# == 1 ]]; then
   export CUDA_VISIBLE_DEVICES=$1
@@ -21,8 +21,8 @@ else
   CGPU=-1
 fi
 
-TIMEOUT=600
-LONGTIMEOUT=600
+TIMEOUT=${TIMEOUT:-600}
+LONGTIMEOUT=${LONGTIMEOUT:-600}
 
 runcmd() {
   LFILE=log/$2$GPUSUF/$4.log
@@ -44,7 +44,8 @@ runcmd() {
     fi
     mkdir -p log/$2$GPUSUF
     echo "$mycmd $3 $MYTIMEOUT &> $LFILE"
-    eval "$mycmd $3 $MYTIMEOUT &> $LFILE"
+    EXTERNALTIMEOUT=$((MYTIMEOUT+60))
+    timeout $EXTERNALTIMEOUT $mycmd $3 $MYTIMEOUT &> $LFILE
   fi
 }
 


### PR DESCRIPTION
Added .travis.yml with a different job for each evaluated framework, except pytorch (which is not being run by run-tests.sh) and tensorflow (due to runtime errors).
Python dynet is installed from pip (latest release), whereas C++ dynet is installed from GitHub master.
Also modified run-tests.sh to accept alternative external values for some variables, and to kill tests that exceed their specified timeout by more than a minute.
To enable pytorch and tensorflow, just add ```TEST="http://download.pytorch.org/whl/cu75/torch-0.2.0.post3-`python python-tag-abi-tag.py`-manylinux1_x86_64.whl torchvision"``` and `TEST=tensorflow` respectively to `env` (see [python python-tag-abi-tag.py](https://github.com/pytorch/builder/blob/master/manywheel/build_scripts/python-tag-abi-tag.py)).
Once merged, cron jobs can be enabled to have a weekly benchmark test, for example.
Note the results are printed in the test output but not saved or sent anywhere yet.