### PR TITLE
Split tasks to separate jobs on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ matrix:
         - cmake .. -DEIGEN3_INCLUDE_DIR=$TRAVIS_BUILD_DIR/eigen
         - make -j$(nproc)
         - cd $TRAVIS_BUILD_DIR/dynet-cpp
-        - make DYNET_PATH=$DYNET_PATH EIGEN_PATH=$EIGEN_PATH
+        - make -j$(nproc) DYNET_PATH=$DYNET_PATH EIGEN_PATH=$EIGEN_PATH
         - cd $TRAVIS_BUILD_DIR
 
 install:
@@ -34,7 +34,7 @@ install:
   - pip install $TEST
 
 script:
-  - env DYFLAGS="--dynet-mem 2048" TIMEOUT=30 LONGTIMEOUT=60 ./run-tests.sh
+  - env DYFLAGS="--dynet-mem 2048" TIMEOUT=5 LONGTIMEOUT=10 ./run-tests.sh
   - grep '\(per_sec\|startup\)' log/*/*.log
 
 after_failure:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,18 +23,14 @@ matrix:
         - export DYNET_PATH=$PWD/dynet EIGEN_PATH=$PWD/eigen
         - mkdir dynet/build
         - cd dynet/build
-        - cmake .. -DEIGEN3_INCLUDE_DIR=$TRAVIS_BUILD_DIR/eigen -DPYTHON=$(which python) -DCMAKE_INSTALL_PREFIX=$(dirname $(which python))/..
+        - cmake .. -DEIGEN3_INCLUDE_DIR=$TRAVIS_BUILD_DIR/eigen
         - make -j$(nproc)
-#        - cd python
-#        - python ../../setup.py build --build-dir=.. --skip-build install
         - cd $TRAVIS_BUILD_DIR/dynet-cpp
         - make DYNET_PATH=$DYNET_PATH EIGEN_PATH=$EIGEN_PATH
         - cd $TRAVIS_BUILD_DIR
 
-before_install:
-  - pip install -q cython numpy
-
 install:
+  - pip install -q cython numpy
   - pip install $TEST
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,18 +4,28 @@ python:
   - 2.7
 env:
   global:
-    - DYNET_PATH=$PWD/dynet EIGEN_PATH=$PWD/eigen DYFLAGS="--dynet-mem 2048" TIMEOUT=400 LONGTIMEOUT=450
+    - DYNET_PATH=$PWD/dynet EIGEN_PATH=$PWD/eigen DYFLAGS="--dynet-mem 2048" TIMEOUT=200 LONGTIMEOUT=300
   matrix:
-    - TEST=dynet TASK=rnnlm-batch
-    - TEST=dynet TASK=sparse-rnnlm-batch
+    - TEST=dynet TASK=rnnlm-batch MBSIZE=64
+    - TEST=dynet TASK=rnnlm-batch MBSIZE=16
+    - TEST=dynet TASK=rnnlm-batch MBSIZE=04
+    - TEST=dynet TASK=rnnlm-batch MBSIZE=01
+    - TEST=dynet TASK=sparse-rnnlm-batch MBSIZE=16
+    - TEST=dynet TASK=sparse-rnnlm-batch MBSIZE=01
     - TEST=dynet TASK=bilstm-tagger
     - TEST=dynet TASK=bilstm-tagger-withchar
     - TEST=dynet TASK=treenn
-    - TEST=chainer TASK=rnnlm-batch
+    - TEST=chainer TASK=rnnlm-batch MBSIZE=64
+    - TEST=chainer TASK=rnnlm-batch MBSIZE=16
+    - TEST=chainer TASK=rnnlm-batch MBSIZE=04
+    - TEST=chainer TASK=rnnlm-batch MBSIZE=01
     - TEST=chainer TASK=bilstm-tagger
     - TEST=chainer TASK=bilstm-tagger-withchar
     - TEST=chainer TASK=treenn
-    - TEST=theano TASK=rnnlm-batch
+    - TEST=theano TASK=rnnlm-batch MBSIZE=64
+    - TEST=theano TASK=rnnlm-batch MBSIZE=16
+    - TEST=theano TASK=rnnlm-batch MBSIZE=04
+    - TEST=theano TASK=rnnlm-batch MBSIZE=01
     - TEST=theano TASK=bilstm-tagger
     - TEST=theano TASK=bilstm-tagger-withchar
 cache:
@@ -41,36 +51,33 @@ jobs:
             - libboost-regex1.55-dev
       install: skip
       script:
-        - hg clone https://bitbucket.org/eigen/eigen -r 699b659
-        - git clone https://github.com/clab/dynet
-        - mkdir dynet/build
+        - hg clone https://bitbucket.org/eigen/eigen -r 699b659 || (cd eigen && hg pull && hg update -r 699b659)
+        - git clone https://github.com/clab/dynet || (cd dynet; git pull)
+        - mkdir -p dynet/build
         - cd dynet/build
         - cmake .. -DEIGEN3_INCLUDE_DIR=$TRAVIS_BUILD_DIR/eigen
         - make -j$(nproc)
-        - cd $TRAVIS_BUILD_DIR/dynet-cpp
-        - make -j$(nproc) DYNET_PATH=$DYNET_PATH EIGEN_PATH=$EIGEN_PATH
-        - cd $TRAVIS_BUILD_DIR
     - stage: test
     - language: cpp
       python:
       env: TEST=dynet TASK=rnnlm-batch
-      install: skip
+      install: cd $TRAVIS_BUILD_DIR/dynet-cpp && make -j$(nproc) DYNET_PATH=$DYNET_PATH EIGEN_PATH=$EIGEN_PATH $TASK && cd $TRAVIS_BUILD_DIR
     - language: cpp
       python:
       env: TEST=dynet TASK=sparse-rnnlm-batch
-      install: skip
+      install: cd $TRAVIS_BUILD_DIR/dynet-cpp && make -j$(nproc) DYNET_PATH=$DYNET_PATH EIGEN_PATH=$EIGEN_PATH $TASK && cd $TRAVIS_BUILD_DIR
     - language: cpp
       python:
       env: TEST=dynet TASK=bilstm-tagger
-      install: skip
+      install: cd $TRAVIS_BUILD_DIR/dynet-cpp && make -j$(nproc) DYNET_PATH=$DYNET_PATH EIGEN_PATH=$EIGEN_PATH $TASK && cd $TRAVIS_BUILD_DIR
     - language: cpp
       python:
       env: TEST=dynet TASK=bilstm-tagger-withchar
-      install: skip
+      install: cd $TRAVIS_BUILD_DIR/dynet-cpp && make -j$(nproc) DYNET_PATH=$DYNET_PATH EIGEN_PATH=$EIGEN_PATH $TASK && cd $TRAVIS_BUILD_DIR
     - language: cpp
       python:
       env: TEST=dynet TASK=treenn
-      install: skip
+      install: cd $TRAVIS_BUILD_DIR/dynet-cpp && make -j$(nproc) DYNET_PATH=$DYNET_PATH EIGEN_PATH=$EIGEN_PATH $TASK && cd $TRAVIS_BUILD_DIR
 
 install:
   - pip install -q cython numpy

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,34 @@ language: python
 python:
   - 2.7
 env:
-  - TEST=dynet
-  - TEST=chainer
-  - TEST=theano
-matrix:
+  global:
+    - DYNET_PATH=$PWD/dynet EIGEN_PATH=$PWD/eigen DYFLAGS="--dynet-mem 2048" 
+  matrix:
+    - TEST=dynet TASK=rnnlm-batch
+    - TEST=dynet TASK=sparse-rnnlm-batch
+    - TEST=dynet TASK=bilstm-tagger
+    - TEST=dynet TASK=bilstm-tagger-withchar
+    - TEST=dynet TASK=treenn
+    - TEST=chainer TASK=rnnlm-batch
+    - TEST=chainer TASK=bilstm-tagger
+    - TEST=chainer TASK=bilstm-tagger-withchar
+    - TEST=chainer TASK=treenn
+    - TEST=theano TASK=rnnlm-batch
+    - TEST=theano TASK=bilstm-tagger
+    - TEST=theano TASK=bilstm-tagger-withchar
+cache:
+  directories:
+    - dynet
+    - eigen
+stages:
+  - compile
+  - test
+jobs:
   include:
-    - env: TEST=dynet-cpp
+    - stage: compile
+      env:
+      language: cpp
+      python:
       addons:
         apt:
           sources:
@@ -17,10 +39,10 @@ matrix:
           packages:
             - g++-4.8
             - libboost-regex1.55-dev
-      install:
+      install: skip
+      script:
         - hg clone https://bitbucket.org/eigen/eigen -r 699b659
         - git clone https://github.com/clab/dynet
-        - export DYNET_PATH=$PWD/dynet EIGEN_PATH=$PWD/eigen
         - mkdir dynet/build
         - cd dynet/build
         - cmake .. -DEIGEN3_INCLUDE_DIR=$TRAVIS_BUILD_DIR/eigen
@@ -28,13 +50,34 @@ matrix:
         - cd $TRAVIS_BUILD_DIR/dynet-cpp
         - make -j$(nproc) DYNET_PATH=$DYNET_PATH EIGEN_PATH=$EIGEN_PATH
         - cd $TRAVIS_BUILD_DIR
+    - stage: test
+    - language: cpp
+      python:
+      env: TEST=dynet TASK=rnnlm-batch
+      install: skip
+    - language: cpp
+      python:
+      env: TEST=dynet TASK=sparse-rnnlm-batch
+      install: skip
+    - language: cpp
+      python:
+      env: TEST=dynet TASK=bilstm-tagger
+      install: skip
+    - language: cpp
+      python:
+      env: TEST=dynet TASK=bilstm-tagger-withchar
+      install: skip
+    - language: cpp
+      python:
+      env: TEST=dynet TASK=treenn
+      install: skip
 
 install:
   - pip install -q cython numpy
-  - pip install $TEST
+  - pip install -U $TEST
 
 script:
-  - env DYFLAGS="--dynet-mem 2048" TIMEOUT=5 LONGTIMEOUT=10 ./run-tests.sh
+  - ./run-tests.sh
   - grep '\(per_sec\|startup\)' log/*/*.log
 
 after_failure:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
   - 2.7
 env:
   global:
-    - DYNET_PATH=$PWD/dynet EIGEN_PATH=$PWD/eigen DYFLAGS="--dynet-mem 2048" 
+    - DYNET_PATH=$PWD/dynet EIGEN_PATH=$PWD/eigen DYFLAGS="--dynet-mem 2048" TIMEOUT=400 LONGTIMEOUT=450
   matrix:
     - TEST=dynet TASK=rnnlm-batch
     - TEST=dynet TASK=sparse-rnnlm-batch

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -49,62 +49,74 @@ runcmd() {
   fi
 }
 
-for trial in 1 2 3; do
+NUM_TRIALS=${NUM_TRIALS:-3}
 
-  # Run rnnlm-batch
-  for embsize in 128; do
-    hidsize=$(($embsize*2))
-    for mbsize in 64 16 04 01; do
-      for f in dynet-cpp dynet-py chainer theano tensorflow; do
-        if [[ $f == "dynet-cpp" ]]; then
-          runcmd $f rnnlm-seq "$mbsize $embsize $hidsize 0" $f-ms$mbsize-es$embsize-hs$hidsize-sp0-t$trial
-        fi
-        runcmd $f rnnlm-batch "$mbsize $embsize $hidsize 0" $f-ms$mbsize-es$embsize-hs$hidsize-sp0-t$trial
+for trial in `seq $NUM_TRIALS`; do
+
+  if [[ -z "$TASK" || "$TASK" == "rnnlm-batch" ]]; then
+    # Run rnnlm-batch
+    for embsize in 128; do
+      hidsize=$(($embsize*2))
+      for mbsize in 64 16 04 01; do
+        for f in dynet-cpp dynet-py chainer theano tensorflow; do
+          if [[ $f == "dynet-cpp" ]]; then
+            runcmd $f rnnlm-seq "$mbsize $embsize $hidsize 0" $f-ms$mbsize-es$embsize-hs$hidsize-sp0-t$trial
+          fi
+          runcmd $f rnnlm-batch "$mbsize $embsize $hidsize 0" $f-ms$mbsize-es$embsize-hs$hidsize-sp0-t$trial
+        done
       done
     done
-  done
+  fi
 
-  # run sparse rnnlm-batch on a subset
-  for embsize in 128; do
-    hidsize=$(($embsize*2))
-    for mbsize in 16 01; do
-      for f in dynet-cpp dynet-py; do
-        runcmd $f rnnlm-batch "$mbsize $embsize $hidsize 1" $f-ms$mbsize-es$embsize-hs$hidsize-sp1-t$trial
+  if [[ -z "$TASK" || "$TASK" == "sparse-rnnlm-batch" ]]; then
+    # run sparse rnnlm-batch on a subset
+    for embsize in 128; do
+      hidsize=$(($embsize*2))
+      for mbsize in 16 01; do
+        for f in dynet-cpp dynet-py; do
+          runcmd $f rnnlm-batch "$mbsize $embsize $hidsize 1" $f-ms$mbsize-es$embsize-hs$hidsize-sp1-t$trial
+        done
       done
     done
-  done
+  fi
 
-  # Run bilstm-tagger
-  wembsize=128
-  hidsize=50
-  mlpsize=32
-  for f in dynet-cpp dynet-py chainer theano tensorflow; do
-    runcmd $f bilstm-tagger "$wembsize $hidsize $mlpsize 0" $f-ws$wembsize-hs$hidsize-mlps$mlpsize-su0-t$trial
-    if [[ $f == dynet* ]]; then
-      runcmd $f bilstm-tagger "$wembsize $hidsize $mlpsize 1" $f-ws$wembsize-hs$hidsize-mlps$mlpsize-su1-t$trial
-    fi
-  done
+  if [[ -z "$TASK" || "$TASK" == "bilstm-tagger" ]]; then
+    # Run bilstm-tagger
+    wembsize=128
+    hidsize=50
+    mlpsize=32
+    for f in dynet-cpp dynet-py chainer theano tensorflow; do
+      runcmd $f bilstm-tagger "$wembsize $hidsize $mlpsize 0" $f-ws$wembsize-hs$hidsize-mlps$mlpsize-su0-t$trial
+      if [[ $f == dynet* ]]; then
+        runcmd $f bilstm-tagger "$wembsize $hidsize $mlpsize 1" $f-ws$wembsize-hs$hidsize-mlps$mlpsize-su1-t$trial
+      fi
+    done
+  fi
 
-  # Run bilstm-tagger-withchar
-  cembsize=20
-  wembsize=128
-  hidsize=50
-  mlpsize=32
-  for f in dynet-cpp dynet-py theano chainer; do
-    runcmd $f bilstm-tagger-withchar "$cembsize $wembsize $hidsize $mlpsize 0" $f-cs$cembsize-ws$wembsize-hs$hidsize-mlps$mlpsize-su0-t$trial
-    if [[ $f == dynet* ]]; then
-      runcmd $f bilstm-tagger-withchar "$cembsize $wembsize $hidsize $mlpsize 1" $f-cs$cembsize-ws$wembsize-hs$hidsize-mlps$mlpsize-su1-t$trial
-    fi
-  done
+  if [[ -z "$TASK" || "$TASK" == "bilstm-tagger-withchar" ]]; then
+    # Run bilstm-tagger-withchar
+    cembsize=20
+    wembsize=128
+    hidsize=50
+    mlpsize=32
+    for f in dynet-cpp dynet-py theano chainer; do
+      runcmd $f bilstm-tagger-withchar "$cembsize $wembsize $hidsize $mlpsize 0" $f-cs$cembsize-ws$wembsize-hs$hidsize-mlps$mlpsize-su0-t$trial
+      if [[ $f == dynet* ]]; then
+        runcmd $f bilstm-tagger-withchar "$cembsize $wembsize $hidsize $mlpsize 1" $f-cs$cembsize-ws$wembsize-hs$hidsize-mlps$mlpsize-su1-t$trial
+      fi
+    done
+  fi
 
-  # Run treenn
-  wembsize=128
-  hidsize=128
-  for f in dynet-cpp dynet-py chainer; do
-    runcmd $f treenn "$wembsize $hidsize 0" $f-ws$wembsize-hs$hidsize-su0-t$trial
-    if [[ $f == dynet* ]]; then
-      runcmd $f treenn "$wembsize $hidsize 1" $f-ws$wembsize-hs$hidsize-su1-t$trial
-    fi
-  done
+  if [[ -z "$TASK" || "$TASK" == "treenn" ]]; then
+    # Run treenn
+    wembsize=128
+    hidsize=128
+    for f in dynet-cpp dynet-py chainer; do
+      runcmd $f treenn "$wembsize $hidsize 0" $f-ws$wembsize-hs$hidsize-su0-t$trial
+      if [[ $f == dynet* ]]; then
+        runcmd $f treenn "$wembsize $hidsize 1" $f-ws$wembsize-hs$hidsize-su1-t$trial
+      fi
+    done
+  fi
 
 done

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -58,12 +58,14 @@ for trial in `seq $NUM_TRIALS`; do
     for embsize in 128; do
       hidsize=$(($embsize*2))
       for mbsize in 64 16 04 01; do
-        for f in dynet-cpp dynet-py chainer theano tensorflow; do
-          if [[ $f == "dynet-cpp" ]]; then
-            runcmd $f rnnlm-seq "$mbsize $embsize $hidsize 0" $f-ms$mbsize-es$embsize-hs$hidsize-sp0-t$trial
-          fi
-          runcmd $f rnnlm-batch "$mbsize $embsize $hidsize 0" $f-ms$mbsize-es$embsize-hs$hidsize-sp0-t$trial
-        done
+        if [[ -z "$MBSIZE" || "$MBSIZE" == "$mbsize" ]]; then
+          for f in dynet-cpp dynet-py chainer theano tensorflow; do
+            if [[ $f == "dynet-cpp" ]]; then
+              runcmd $f rnnlm-seq "$mbsize $embsize $hidsize 0" $f-ms$mbsize-es$embsize-hs$hidsize-sp0-t$trial
+            fi
+            runcmd $f rnnlm-batch "$mbsize $embsize $hidsize 0" $f-ms$mbsize-es$embsize-hs$hidsize-sp0-t$trial
+          done
+        fi
       done
     done
   fi
@@ -73,9 +75,11 @@ for trial in `seq $NUM_TRIALS`; do
     for embsize in 128; do
       hidsize=$(($embsize*2))
       for mbsize in 16 01; do
-        for f in dynet-cpp dynet-py; do
-          runcmd $f rnnlm-batch "$mbsize $embsize $hidsize 1" $f-ms$mbsize-es$embsize-hs$hidsize-sp1-t$trial
-        done
+        if [[ -z "$MBSIZE" || "$MBSIZE" == "$mbsize" ]]; then
+          for f in dynet-cpp dynet-py; do
+            runcmd $f rnnlm-batch "$mbsize $embsize $hidsize 1" $f-ms$mbsize-es$embsize-hs$hidsize-sp1-t$trial
+          done
+        fi
       done
     done
   fi


### PR DESCRIPTION
Due to the long build time (~10 minutes), the C++ run wasn't finishing on time for the Travis CI limit of 50 minutes. Setting the timeout to 5 seconds means that most tests won't do anything but startup, but at least the test doesn't fail: https://travis-ci.org/danielhers/dynet-benchmark/jobs/289413251